### PR TITLE
Update db_config_file.properties file

### DIFF
--- a/proxl_importer/config_sample_files_RUN_proxl_xml_importer_PGM/run_importer_config_file.properties
+++ b/proxl_importer/config_sample_files_RUN_proxl_xml_importer_PGM/run_importer_config_file.properties
@@ -19,13 +19,18 @@ java.executable.with.path=
 
 #     This must be an absolute path or must be a path relative to the directory the importer will be run in.
 #     This cannot be relative to the path the "Run Importer" program is run in.
+#     When specifying the path in windows installation you need to add two backslashes to allow the 
+#     the jar file to read the path correctly e.g.
+#     D:\\jar file folder\\importProxlXML.jar
 
 importer.jar.with.path=
 
-#  optional importer config file with path if a db_config_file.properties hasn't been rolled into the importer jar 
+#     optional importer config file with path if a db_config_file.properties hasn't been rolled into the importer jar 
 #     This string is passed to the importer with the "-c" command line parameter
-importer.db.config.file.with.path=
+#     Again in windows the path should be specify in the following manner
+#     D:\\jar file folder\\config_sample_files_proxl_xml_importer\\db_config_file.properties
 
+importer.db.config.file.with.path=
 
 #  Proxl Web app Base URL  - machine URL and proxl context (context usually 'proxl')
 


### PR DESCRIPTION
In windows installations it is important to have two backslash, when specifying the paths to jar file and property file